### PR TITLE
Replace frontend-logger with web-logger

### DIFF
--- a/.changeset/default-url-patch.md
+++ b/.changeset/default-url-patch.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/ts-logger": patch
+---
+
+Change the default relative URL for logging from `/services/frontend-logger` to `/web-services/web-logger`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const logger = getLogger({ source: "my-app", environment: "wonky" });
 
 ### Override the URL
 
-By default, the logger will log to the relative URL `/services/frontend-logger`, but you can override this by passing a `url` option to the `getLogger` function.
+By default, the logger will log to the relative URL `/web-services/web-logger`, but you can override this by passing a `url` option to the `getLogger` function.
 
 ```ts
 import { getLogger } from "@vygruppen/ts-logger";

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ class LogClient {
   private constructor({
     source,
     environment,
-    url = "/services/frontend-logger",
+    url = "/web-services/web-logger",
   }: CreateLogClientArgs) {
     this.source = source;
     this.environment = environment ?? this.getLogEnvironment();


### PR DESCRIPTION
web-logger er nå oppe og kjører på /web-services/web-logger i prod og testmiljø