### PR TITLE
Added handling of stage environment

### DIFF
--- a/.changeset/heavy-pots-tease.md
+++ b/.changeset/heavy-pots-tease.md
@@ -1,0 +1,5 @@
+---
+"@vygruppen/ts-logger": patch
+---
+
+Added handling of stage environment, so that logs from test4 and stage are sent to the stage environment in web-logger

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vygruppen/ts-logger",
-  "version": "0.0.2",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vygruppen/ts-logger",
-      "version": "0.0.2",
+      "version": "0.0.5",
       "devDependencies": {
         "@changesets/cli": "^2.25.2",
         "typescript": "^4.6.4",

--- a/src/environment-utils.ts
+++ b/src/environment-utils.ts
@@ -10,7 +10,13 @@ export function isTest() {
   return !!host && host.indexOf("test") >= 0;
 }
 
+/** Checks whether or not we're in a stage environment */
+export function isStage() {
+  var host = window.location.hostname;
+  return !!host && (host.indexOf("test4") >= 0 || host.indexOf("stage") >= 0);
+}
+
 /** Checks whether or not we're in a production environment */
 export function isProduction() {
-  return !isLocalhost() && !isTest();
+  return !isLocalhost() && !isTest() && !isStage();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { isLocalhost, isProduction } from "./environment-utils";
+import { isLocalhost, isProduction, isStage } from "./environment-utils";
 
 type LogArgs = {
   /** The log message you want logged */
@@ -109,6 +109,9 @@ class LogClient {
   private getLogEnvironment() {
     if (isProduction()) {
       return "prod";
+    }
+    if (isStage()) {
+      return "stage";
     }
     if (isLocalhost()) {
       return undefined;


### PR DESCRIPTION
The environment of logs defaulted to "prod" if the subdomain of the url did not start with "test".

As we have three environments in weblogger (test, stage and prod), we should map loggs from our stage environments ("stage.vy.no" and "test4.vy.no") to the "stage" environment.

Several of our frontends run playwright tests on stage.vy.no, when running in circleCI, which means that circleCi logs are mixed within all of the prod logs.